### PR TITLE
Update python-test-and-build.yml

### DIFF
--- a/.github/workflows/python-test-and-build.yml
+++ b/.github/workflows/python-test-and-build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.13", "3.12", "3.11", "3.10"]
+        python-version: ["3.13", "3.12", "3.11"]
 
     steps:
       - name: checkout


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Drop support for Python 3.10.