### PR TITLE
use flit for build and publish

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+### Release 5.3.3
+
+- Workaround bug in publishing using the default setuptools and just use flit.
+
 ### Release 5.3.0
 
 - Unified all url parsing functions into a single module and return a ParsedUrl instead of a dictionary

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
-The MIT License (MIT)
+# The MIT License (MIT)
 
-Copyright (c) 2021 News Corp Australia
+**Copyright (c) 2024 David L Nugent**
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -12,10 +12,10 @@ furnished to do so, subject to the following conditions:
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+**THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+SOFTWARE.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,14 @@
 [project]
 name = "django-settings-env"
-version = "5.3.2"
+version = "5.3.3"
 description = "12-factor.net settings handler for Django"
 authors = [
     {name = "David Nugent", email = "davidn@uniquode.io"}
 ]
-license = {text = "MIT"}
+license = {file = "LICENSE.md"}
 readme = "README.md"
 requires-python = ">=3.11"
 classifiers = [
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -48,3 +47,7 @@ vault = [
 minversion = "7.0"
 addopts = "-ra -q"
 pythonpath = [ "." ]
+
+[build-system]
+requires = ["flit-core"]
+build-backend = "flit_core.buildapi"

--- a/uv.lock
+++ b/uv.lock
@@ -164,8 +164,8 @@ wheels = [
 
 [[package]]
 name = "django-settings-env"
-version = "5.3.0"
-source = { virtual = "." }
+version = "5.3.3"
+source = { editable = "." }
 dependencies = [
     { name = "django" },
     { name = "envex" },


### PR DESCRIPTION
## Summary by Sourcery

Update project to version 5.3.3 and switch to flit for building and publishing.

Build:
- Switch to flit for building and publishing the project.

Chores:
- Increment the project version to 5.3.3.