### PR TITLE
Support redis+socket scheme in cache plugin

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,7 @@
 # ChangeLog
+### Release 5.4.1
+
+ - Added support for redis+socket urls
 
 ### Release 5.4.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "django-settings-env"
-version = "5.4.0"
+version = "5.4.1"
 description = "12-factor.net settings handler for Django"
 authors = [
     {name = "David Nugent", email = "davidn@uniquode.io"}
@@ -12,11 +12,10 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "Framework :: Django :: 4.0",
-    "Framework :: Django :: 4.1",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
     "Framework :: Django :: 5.1",
+    "Framework :: Django :: 5.2",
 ]
 dependencies = [
     "django>=5.0",
@@ -45,7 +44,7 @@ vault = [
 ]
 
 [tool.pytest.ini-options]
-minversion = "7.0"
+minversion = "8.0"
 addopts = "-ra -q"
 pythonpath = [ "." ]
 

--- a/tests/plugin/test_cache.py
+++ b/tests/plugin/test_cache.py
@@ -59,6 +59,13 @@ def test_cache_plugin_get_backend_special_case_unix(cache_plugin):
     assert result["LOCATION"] == "unix:///tmp/redis.sock"
 
 
+def test_cache_plugin_get_backend_special_case_socket(cache_plugin):
+    url = "redis+socket:///var/run/redis/redis.sock"
+    result = cache_plugin.get_backend(url)
+    assert result["BACKEND"] == "django.core.cache.backends.redis.RedisCache"
+    assert result["LOCATION"] == "socket:///var/run/redis/redis.sock"
+
+
 def test_cache_plugin_get_backend_invalid_scheme(cache_plugin):
     url = "cache_unknown_scheme:///"
     with pytest.raises(ValueError, match="Missing cache scheme or url parse error"):


### PR DESCRIPTION
- Added handling for the redis+socket scheme in cache backend configuration and updated tests to cover the new special case.
- Simplified handler logic on dependency django version

## Summary by Sourcery

Add support for redis+socket scheme in cache plugin configuration

New Features:
- Introduced support for 'redis+socket' URL scheme in cache backend configuration

Enhancements:
- Simplified Redis cache backend handling logic across different Django versions

Tests:
- Added test case to verify redis+socket URL handling