### PR TITLE
Django's redis handler prefers unix scheme

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,5 @@
 # ChangeLog
-### Release 5.4.1
+### Release 5.4.2
 
  - Added support for redis+socket urls
 

--- a/django_settings_env/plugin/plugin_cache.py
+++ b/django_settings_env/plugin/plugin_cache.py
@@ -52,17 +52,13 @@ class CachePlugin(EnvPlugin):
         match parsed.scheme:
             case "filecache":
                 config["LOCATION"] = f"{host}{name}"
-            case "redis" | "rediscache" | "pymemcache":
+            case "redis" | "rediscache" | "pymemcache" | "redis+socket":
                 # note: SSL is not supported for unix domain sockets, so "rediss" is not here
                 if parsed.hostname == "unix" or not parsed.hostname:
                     path = name or "/tmp/redis.sock"
                     config["LOCATION"] = f"unix://{path}"
                 else:
                     config["LOCATION"] = parsed.to_url()
-            case "redis+socket":
-                # special case for redis+socket
-                path = name or "/tmp/redis.sock"
-                config["LOCATION"] = f"socket://{path}"
             case "dummycache":
                 config["LOCATION"] = config["NAME"] = None
             case "dbcache":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "django-settings-env"
-version = "5.4.1"
+version = "5.4.2"
 description = "12-factor.net settings handler for Django"
 authors = [
     {name = "David Nugent", email = "davidn@uniquode.io"}

--- a/tests/plugin/test_cache.py
+++ b/tests/plugin/test_cache.py
@@ -63,7 +63,7 @@ def test_cache_plugin_get_backend_special_case_socket(cache_plugin):
     url = "redis+socket:///var/run/redis/redis.sock"
     result = cache_plugin.get_backend(url)
     assert result["BACKEND"] == "django.core.cache.backends.redis.RedisCache"
-    assert result["LOCATION"] == "socket:///var/run/redis/redis.sock"
+    assert result["LOCATION"] == "unix:///var/run/redis/redis.sock"
 
 
 def test_cache_plugin_get_backend_invalid_scheme(cache_plugin):


### PR DESCRIPTION
## Summary by Sourcery

Improve Redis socket URL handling in Django cache backend plugin

New Features:
- Add support for 'redis+socket' URL scheme in cache backend configuration

Bug Fixes:
- Fix Redis socket URL parsing to consistently use 'unix://' location for socket connections

Enhancements:
- Consolidate Redis socket URL handling to prefer 'unix://' scheme